### PR TITLE
moved torchaudio to pip install

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -5,10 +5,9 @@ channels:
   - conda-forge
   - defaults
 dependencies:
-  - python==3.8
-  - pytorch==1.11.0
-  - torchvision==0.12.0
-  - torchaudio==0.11.0
+  - python=3.8
+  - pytorch=1.11.0
+  - torchvision=0.12.0
   - pip>=20.2
   - numpy
   - pandas
@@ -19,6 +18,7 @@ dependencies:
   - libsndfile
   - sox
   - pip:
+    - torchaudio==0.11.0
     - pympi-ling
     - pyannote.audio==2.1.1
     - speechbrain


### PR DESCRIPTION
For some reason, `torchaudio=0.11.0` could not be installed with conda. I moved it to be a pip install, and the environment could then be created. 