### PR TITLE
Environment changeup

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -6,8 +6,6 @@ channels:
   - defaults
 dependencies:
   - python=3.8
-  - pytorch=1.11.0
-  - torchvision=0.12.0
   - pip>=20.2
   - numpy
   - pandas
@@ -18,6 +16,8 @@ dependencies:
   - libsndfile
   - sox
   - pip:
+    - torch==1.11.0
+    - torchvision==0.12.0
     - torchaudio==0.11.0
     - pympi-ling
     - pyannote.audio==2.1.1

--- a/environment.yml
+++ b/environment.yml
@@ -5,10 +5,9 @@ channels:
   - conda-forge
   - defaults
 dependencies:
-  - python==3.8
-  - pytorch==1.11.0
-  - torchvision==0.12.0
-  - torchaudio==0.11.0
+  - python=3.8
+  - pytorch=1.11.0
+  - torchvision=0.12.0
   - pip>=20.2
   - numpy
   - pandas
@@ -19,6 +18,7 @@ dependencies:
   - libsndfile
   - sox
   - pip:
+    - torchaudio==0.11.0
     - pympi-ling
     - pyannote.audio==2.1.1
     - speechbrain


### PR DESCRIPTION
When trying to create environment as-is:

```bash
conda env create -f environment.yml --name diarize
```

conda returns the following error

```
ResolvePackageNotFound: 
  - python==3.8
  - torchaudio==0.11.0
```

Changing line 8 to `-python=3.8` still returns this error:

```
ResolvePackageNotFound: 
  - torchaudio==0.11.0
```

Trying to directly create a conda environment with `torchaudio=0.11.0` results in the same error

```bash
conda create -n diarize -c pytorch torchaudio=0.11.0
```

I tried moving *just* torchaudio to be a pip dependency, but installing pytorch with conda and torchaudio with pip created problems when trying to import torchaudio.

Moving all of pytorch over to a pip dependency did the trick, and I can confirm I was able to run the notebook successfully.
